### PR TITLE
Shrink header on phones and add trip blurb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,5 @@
-# React + Vite
+# Costa Rica Trip Schedule
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+An interactive schedule to plan our week in Costa Rica based on everyone's spreadsheet responses. Bright, simple, and a little beachy. ☀️🌴
 
-Currently, two official plugins are available:
-
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+Built with [React](https://react.dev/) and [Vite](https://vitejs.dev/).

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -53,7 +53,7 @@ export default function App() {
       <header className="site-header">
         <div className="site-header__titles">
           <h1 className="site-title">Costa Rica Trip — Schedule</h1>
-          <p className="site-subtitle">Bright, simple, and beachy ☀️🌴</p>
+          <p className="site-subtitle">Bright, simple, and beachy ☀️🌴 Built from everyone's spreadsheet responses to help plan our week in paradise!</p>
         </div>
         <div className="site-header__actions">
           <input

--- a/src/index.css
+++ b/src/index.css
@@ -38,6 +38,12 @@ body{
 .site-subtitle{margin:0; color:var(--muted); font-size:14px}
 .site-header__actions{margin-top:10px; display:flex; gap:10px; flex-wrap:wrap}
 
+@media (max-width: 480px){
+  .site-header{padding:12px 16px; margin:-28px -20px 12px;}
+  .site-title{font-size:20px;}
+  .site-subtitle{font-size:12px;}
+}
+
 .btn{
   background: #fff;
   border:1px solid var(--line);


### PR DESCRIPTION
## Summary
- tighten header font sizes and spacing on screens under 480px
- add a playful note about planning our week from spreadsheet responses
- rewrite README to describe the Costa Rica trip schedule

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689aa37920208333a9c0a7751de54522