### PR TITLE
Show F schedule by default

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import { D, E, F } from "./data/options";
 import { timeGuess } from "./utils/time";
 
 export default function App() {
-  const [active, setActive] = useState("D");
+  const [active, setActive] = useState("F");
   const [compact, setCompact] = useState(false);
   const [q, setQ] = useState("");
   const [favOnly, setFavOnly] = useState(false);


### PR DESCRIPTION
## Summary
- Default to F schedule on initial load by setting `active` to `"F"`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689aa4d85fc083339f5b89d91a66d098