### PR TITLE
feat: differentiate active tabs

### DIFF
--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -19,7 +19,7 @@ export default function Tabs({ active, onChange }) {
           <button
             key={t}
             id={`tab-${t}`}
-            className={`tab${selected ? " tab--active" : ""}`}
+            className={`tab${selected ? ` tab--active tab--active-${t}` : ""}`}
             role="tab"
             aria-selected={selected}
             aria-controls={`panel-${t}`}

--- a/src/index.css
+++ b/src/index.css
@@ -65,9 +65,12 @@ body{
   padding:10px 14px; border-radius:999px; cursor:pointer; font-weight:700;
 }
 .tab--active{
-  background: linear-gradient(90deg, var(--sea), var(--sun));
-  color:#063; border-color:transparent;
+  background: var(--coral);
+  color:#fff; border-color:transparent;
 }
+.tab--active-D{ background: var(--sea); }
+.tab--active-E{ background: var(--sun); color:#063; }
+.tab--active-F{ background: var(--coral); }
 
 /* toolbar (just search) */
 .toolbar{display:flex; gap:10px; align-items:center; flex-wrap:wrap; margin:6px 0 16px}


### PR DESCRIPTION
## Summary
- emphasize active tabs with a solid accent color
- add tab-specific color variants for options D, E, and F

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689aa4d92afc8333b9de257d20989b13