### PR TITLE
feat: animate option panel transitions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { AnimatePresence } from "framer-motion";
 import Tabs from "./components/Tabs";
 import OptionPanel from "./components/OptionPanel";
 import { D, E, F } from "./data/options";
@@ -77,14 +78,17 @@ export default function App() {
 
       <Tabs active={active} onChange={setActive} />
 
-      <OptionPanel
-        id={`panel-${active}`}
-        labelledById={`tab-${active}`}
-        isActive={true}
-        days={filteredDays}
-        favorites={favs}
-        onToggleFavorite={toggleFav}
-      />
+      <AnimatePresence mode="wait">
+        <OptionPanel
+          key={active}
+          id={`panel-${active}`}
+          labelledById={`tab-${active}`}
+          isActive={true}
+          days={filteredDays}
+          favorites={favs}
+          onToggleFavorite={toggleFav}
+        />
+      </AnimatePresence>
     </div>
   );
 }

--- a/src/components/OptionPanel.jsx
+++ b/src/components/OptionPanel.jsx
@@ -1,9 +1,18 @@
+import { motion as Motion } from "framer-motion";
 import DayCard from "./DayCard";
 
 export default function OptionPanel({ id, isActive, days = [], labelledById, favorites, onToggleFavorite }) {
   if (!isActive) return null;
   return (
-    <div id={id} role="tabpanel" aria-labelledby={labelledById} className="option-panel">
+    <Motion.div
+      id={id}
+      role="tabpanel"
+      aria-labelledby={labelledById}
+      className="option-panel"
+      initial={{ opacity: 0, x: 40 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: -40 }}
+    >
       <div className="days-grid">
         {days.map((d, i) => (
           <DayCard
@@ -15,6 +24,6 @@ export default function OptionPanel({ id, isActive, days = [], labelledById, fav
           />
         ))}
       </div>
-    </div>
+    </Motion.div>
   );
 }


### PR DESCRIPTION
## Summary
- wrap OptionPanel in `AnimatePresence` for panel transition support
- animate option panel mount/unmount with `motion.div`
- key OptionPanel instances by active tab to enable animation

## Testing
- `npx eslint src/App.jsx src/components/OptionPanel.jsx`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689aa4f87df4833380748021aaffbad1