### PR TITLE
feat: add landing page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,10 +3,12 @@ import { AnimatePresence } from "framer-motion";
 import AnimatedBackground from "./components/AnimatedBackground";
 import Tabs from "./components/Tabs";
 import OptionPanel from "./components/OptionPanel";
+import LandingPage from "./components/LandingPage";
 import { D, E, F } from "./data/options";
 import { timeGuess } from "./utils/time";
 
 export default function App() {
+  const [entered, setEntered] = useState(false);
   const [active, setActive] = useState("F");
   const [compact, setCompact] = useState(false);
   const [q, setQ] = useState("");
@@ -50,6 +52,10 @@ export default function App() {
   }, [active, q, favOnly, favs]);
 
   const favCount = favs.size;
+  
+  if (!entered) {
+    return <LandingPage onEnter={() => setEntered(true)} />;
+  }
 
   return (
     <>

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -1,0 +1,19 @@
+import AnimatedBackground from "./AnimatedBackground";
+
+export default function LandingPage({ onEnter }) {
+  return (
+    <>
+      <AnimatedBackground />
+      <div className="landing">
+        <h1 className="site-title">Costa Rica Trip — Schedule</h1>
+        <p className="site-subtitle">
+          Bright, simple, and beachy ☀️🌴 Built from everyone's spreadsheet responses to help plan our week in paradise!
+        </p>
+        <p className="site-explainer">
+          These schedules were generated from everyone's activity preferences and are offered in three tabbed options.
+        </p>
+        <button className="btn btn--primary" onClick={onEnter}>Enter</button>
+      </div>
+    </>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -178,3 +178,17 @@ body.compact .days-grid{gap:12px}
   vertical-align:middle;
   margin-left:6px;
 }
+
+/* landing */
+.landing{
+  min-height:100%;
+  display:flex;
+  flex-direction:column;
+  justify-content:center;
+  align-items:center;
+  text-align:center;
+  padding:40px 20px;
+}
+@media (max-width:480px){
+  .landing{padding:32px 16px;}
+}


### PR DESCRIPTION
## Summary
- add landing page component with site description and enter button
- show landing screen before schedule app loads
- style landing layout for centered presentation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cd7941ae0833383185a4f57d16149