### PR TITLE
Update site subtitle message

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -64,7 +64,9 @@ export default function App() {
         <header className={`site-header ${isHeaderOpen ? "" : "collapsed"}`}>
           <div className="site-header__titles">
             <h1 className="site-title">Costa Rica Trip — Schedule</h1>
-            <p className="site-subtitle">Bright, simple, and beachy ☀️🌴 Built from everyone's spreadsheet responses to help plan our week in paradise!</p>
+            <p className="site-subtitle">
+              So excited for this trip together! These schedules were built from everyone's responses to the activity planning sheet.
+            </p>
           </div>
           <p className="site-explainer">
             These schedules were generated from everyone's activity preferences and are offered in three tabbed options.

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -7,7 +7,7 @@ export default function LandingPage({ onEnter }) {
       <div className="landing">
         <h1 className="site-title">Costa Rica Trip — Schedule</h1>
         <p className="site-subtitle">
-          Bright, simple, and beachy ☀️🌴 Built from everyone's spreadsheet responses to help plan our week in paradise!
+          So excited for this trip together! These schedules were built from everyone's responses to the activity planning sheet.
         </p>
         <p className="site-explainer">
           These schedules were generated from everyone's activity preferences and are offered in three tabbed options.


### PR DESCRIPTION
## Summary
- Replace old “Bright, simple, and beachy” tagline with trip excitement message on landing page and header.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cdd48d7748333a18687ffc9dd2215