### PR TITLE
Add animated tropical icons to background

### DIFF
--- a/src/components/AnimatedBackground.jsx
+++ b/src/components/AnimatedBackground.jsx
@@ -1,4 +1,4 @@
-import { motion, useReducedMotion } from "framer-motion";
+import { motion as Motion, useReducedMotion } from "framer-motion";
 
 export default function AnimatedBackground() {
   const prefersReducedMotion = useReducedMotion();
@@ -32,6 +32,37 @@ export default function AnimatedBackground() {
         },
       };
 
+  const toucanProps = prefersReducedMotion
+    ? {}
+    : {
+        animate: { x: [0, 10, 0], y: [0, -10, 0] },
+        transition: { duration: 8, repeat: Infinity, ease: "easeInOut" },
+      };
+
+  const pineappleProps = prefersReducedMotion
+    ? {}
+    : {
+        animate: { rotate: [0, 360] },
+        transition: { duration: 20, repeat: Infinity, ease: "linear" },
+      };
+
+  const surfboardProps = prefersReducedMotion
+    ? {}
+    : {
+        animate: { y: [0, 15, 0], rotate: [-10, 10, -10] },
+        transition: {
+          y: { duration: 6, repeat: Infinity, ease: "easeInOut" },
+          rotate: { duration: 8, repeat: Infinity, ease: "easeInOut" },
+        },
+      };
+
+  const volcanoProps = prefersReducedMotion
+    ? {}
+    : {
+        animate: { y: [0, 5, 0] },
+        transition: { duration: 4, repeat: Infinity, ease: "easeInOut" },
+      };
+
   return (
     <div
       style={{
@@ -43,11 +74,17 @@ export default function AnimatedBackground() {
       }}
       aria-hidden="true"
     >
-      <motion.svg
+      <Motion.svg
         width="120%"
         height="40%"
         viewBox="0 0 800 200"
-        style={{ position: "absolute", bottom: 0, left: 0 }}
+        style={{
+          position: "absolute",
+          bottom: 0,
+          left: 0,
+          pointerEvents: "none",
+        }}
+        aria-hidden="true"
       >
         <defs>
           <linearGradient id="waveGradient" x1="0" y1="0" x2="0" y2="1">
@@ -55,24 +92,30 @@ export default function AnimatedBackground() {
             <stop offset="100%" stopColor="#00a9a5" />
           </linearGradient>
         </defs>
-        <motion.path
+        <Motion.path
           d="M0 100 Q 100 150 200 100 T 400 100 T 600 100 T 800 100 V200 H0 Z"
           fill="url(#waveGradient)"
           {...waveProps}
         />
-        <motion.path
+        <Motion.path
           d="M0 120 Q 150 170 300 120 T 600 120 T 800 120 V200 H0 Z"
           fill="url(#waveGradient)"
           opacity="0.5"
           {...wavePropsSecondary}
         />
-      </motion.svg>
+      </Motion.svg>
 
-      <motion.svg
+      <Motion.svg
         width="200"
         height="200"
         viewBox="0 0 200 200"
-        style={{ position: "absolute", top: 40, right: 40 }}
+        style={{
+          position: "absolute",
+          top: 40,
+          right: 40,
+          pointerEvents: "none",
+        }}
+        aria-hidden="true"
         {...leafProps}
       >
         <defs>
@@ -103,7 +146,90 @@ export default function AnimatedBackground() {
           strokeWidth="1.5"
           fill="none"
         />
-      </motion.svg>
+      </Motion.svg>
+
+      <Motion.svg
+        width="80"
+        height="80"
+        viewBox="0 0 100 100"
+        style={{
+          position: "absolute",
+          top: 80,
+          left: 40,
+          pointerEvents: "none",
+        }}
+        aria-hidden="true"
+        {...toucanProps}
+      >
+        <circle cx="50" cy="60" r="20" fill="#000" />
+        <circle cx="40" cy="55" r="5" fill="#fff" />
+        <path d="M50 55 L90 45 L90 65 Z" fill="#ffa500" />
+      </Motion.svg>
+
+      <Motion.svg
+        width="60"
+        height="100"
+        viewBox="0 0 60 100"
+        style={{
+          position: "absolute",
+          bottom: 80,
+          left: 80,
+          pointerEvents: "none",
+        }}
+        aria-hidden="true"
+        {...pineappleProps}
+      >
+        <path d="M30 20 L20 0 L40 0 Z" fill="#5da130" />
+        <ellipse
+          cx="30"
+          cy="60"
+          rx="20"
+          ry="30"
+          fill="#f4c430"
+          stroke="#d18b00"
+          strokeWidth="2"
+        />
+        <path d="M15 45 L45 75 M45 45 L15 75" stroke="#d18b00" strokeWidth="2" />
+      </Motion.svg>
+
+      <Motion.svg
+        width="40"
+        height="120"
+        viewBox="0 0 40 120"
+        style={{
+          position: "absolute",
+          top: 120,
+          right: 120,
+          pointerEvents: "none",
+        }}
+        aria-hidden="true"
+        {...surfboardProps}
+      >
+        <path
+          d="M20 0 C35 40 35 80 20 120 C5 80 5 40 20 0 Z"
+          fill="#fff"
+          stroke="#00a9a5"
+        />
+        <line x1="20" y1="0" x2="20" y2="120" stroke="#00a9a5" strokeWidth="2" />
+      </Motion.svg>
+
+      <Motion.svg
+        width="100"
+        height="100"
+        viewBox="0 0 100 100"
+        style={{
+          position: "absolute",
+          bottom: 20,
+          right: 40,
+          pointerEvents: "none",
+        }}
+        aria-hidden="true"
+        {...volcanoProps}
+      >
+        <path d="M20 100 L50 20 L80 100 Z" fill="#7b3f00" />
+        <path d="M45 20 L55 20 L60 10 L40 10 Z" fill="#555" />
+        <path d="M50 20 C50 20 45 40 60 40" stroke="#ff4500" strokeWidth="2" fill="none" />
+      </Motion.svg>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add animated toucan, pineapple, surfboard, and volcano SVGs to the background
- respect reduced motion preferences and disable animations when requested
- ensure decorative SVGs ignore pointer events and remain hidden from accessibility APIs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/components/AnimatedBackground.jsx`


------
https://chatgpt.com/codex/tasks/task_e_689cdd4ed90c8333a3d1119321be3b3f