### PR TITLE
Update site title to Costa Rica Trip 2025

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Costa Rica Trip Schedule Options</title>
+    <title>Costa Rica Trip 2025</title>
     <meta name="description" content="Interactive schedule options for a Costa Rica trip." />
-    <meta property="og:title" content="Costa Rica Trip Schedule Options" />
+    <meta property="og:title" content="Costa Rica Trip 2025" />
     <meta property="og:description" content="Interactive schedule options for a Costa Rica trip." />
     <meta property="og:image" content="/path-to-preview-image.png" />
     <meta property="og:type" content="website" />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -73,7 +73,7 @@ export default function App() {
       <div className="container">
         <header className={`site-header ${isHeaderOpen ? "" : "collapsed"}`}>
           <div className="site-header__titles">
-            <h1 className="site-title">Costa Rica Trip — Schedule</h1>
+            <h1 className="site-title">Costa Rica Trip 2025</h1>
             <p className="site-subtitle">
               So excited for this trip together! These schedules were built from everyone's responses to the activity planning sheet.
             </p>

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -5,7 +5,7 @@ export default function LandingPage({ onEnter, onShowTips, onShowRules }) {
     <>
       <AnimatedBackground />
       <div className="landing">
-        <h1 className="site-title">Costa Rica Trip — Schedule</h1>
+        <h1 className="site-title">Costa Rica Trip 2025</h1>
         <p className="site-subtitle">
           So excited for this trip together! These schedules were built from everyone's responses to the activity planning sheet.
         </p>


### PR DESCRIPTION
## Summary
- replace schedule-focused headers with "Costa Rica Trip 2025" on the landing page and main app header
- update HTML metadata (`<title>` and `og:title`) to match the new trip name

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ce3b9bb388333a2488f83c06a9f28