### PR TITLE
Rename landing page button text

### DIFF
--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -12,7 +12,7 @@ export default function LandingPage({ onEnter, onShowTips, onShowRules }) {
         <p className="site-explainer">
           These schedules were generated from everyone's activity preferences and are offered in three tabbed options.
         </p>
-        <button className="btn btn--primary" onClick={onEnter}>Enter</button>
+        <button className="btn btn--primary" onClick={onEnter}>Activity Schedule</button>
         <button className="btn" onClick={onShowTips}>General Tips & Coordination</button>
         <button className="btn" onClick={onShowRules}>Expectations & House Rules</button>
       </div>


### PR DESCRIPTION
## Summary
- rename the landing page's primary button from "Enter" to "Activity Schedule"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ce3befd9083338c7c00351208213a