### PR TITLE
feat: emphasize navigation buttons

### DIFF
--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -13,8 +13,8 @@ export default function LandingPage({ onEnter, onShowTips, onShowRules }) {
           These schedules were generated from everyone's activity preferences and are offered in three tabbed options.
         </p>
         <button className="btn btn--primary" onClick={onEnter}>Enter</button>
-        <button className="btn" onClick={onShowTips}>General Tips & Coordination</button>
-        <button className="btn" onClick={onShowRules}>Expectations & House Rules</button>
+        <button className="btn btn--primary" onClick={onShowTips}>General Tips & Coordination</button>
+        <button className="btn btn--primary" onClick={onShowRules}>Rules & Expectations</button>
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- highlight all landing page navigation buttons
- rename rules button to use "Rules & Expectations"

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: Missing script "lint" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ce3c2e2fc8333b65c502a5368d300