### PR TITLE
Add animated page transitions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import AnimatedBackground from "./components/AnimatedBackground";
 import OptionPanel from "./components/OptionPanel";
 import LandingPage from "./components/LandingPage";
@@ -18,6 +19,7 @@ export default function App() {
     try { return new Set(JSON.parse(localStorage.getItem("cr-favs") || "[]")); }
     catch { return new Set(); }
   });
+  const prefersReducedMotion = useReducedMotion();
 
   useEffect(() => {
     document.body.classList.toggle("compact", compact);
@@ -56,22 +58,25 @@ export default function App() {
     setPage(p);
   };
 
+  let pageContent;
+
   if (page === "landing") {
-    return <LandingPage onEnter={() => setPage("main")} onShowTips={() => navigate("tips")} onShowRules={() => navigate("rules")} />;
-  }
-
-  if (page === "tips") {
-    return <TipsPage onBack={() => setPage(prevPage || "landing")} />;
-  }
-
-  if (page === "rules") {
-    return <RulesPage onBack={() => setPage(prevPage || "landing")} />;
-  }
-
-  return (
-    <>
-      <AnimatedBackground />
-      <div className="container">
+    pageContent = (
+      <LandingPage
+        onEnter={() => setPage("main")}
+        onShowTips={() => navigate("tips")}
+        onShowRules={() => navigate("rules")}
+      />
+    );
+  } else if (page === "tips") {
+    pageContent = <TipsPage onBack={() => setPage(prevPage || "landing")} />;
+  } else if (page === "rules") {
+    pageContent = <RulesPage onBack={() => setPage(prevPage || "landing")} />;
+  } else {
+    pageContent = (
+      <div className="page page--schedule">
+        <AnimatedBackground />
+        <div className="container">
         <header className={`site-header ${isHeaderOpen ? "" : "collapsed"}`}>
           <div className="site-header__titles">
             <h1 className="site-title">Costa Rica Trip 2025</h1>
@@ -128,8 +133,6 @@ export default function App() {
           </button>
         </header>
 
-
-
         <OptionPanel
           id="panel-schedule"
           isActive={true}
@@ -138,6 +141,21 @@ export default function App() {
           onToggleFavorite={toggleFav}
         />
       </div>
-    </>
+      </div>
+    );
+  }
+
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={page}
+        initial={prefersReducedMotion ? false : { opacity: 0, x: 20 }}
+        animate={prefersReducedMotion ? {} : { opacity: 1, x: 0 }}
+        exit={prefersReducedMotion ? {} : { opacity: 0, x: -20 }}
+        transition={{ duration: 0.3 }}
+      >
+        {pageContent}
+      </motion.div>
+    </AnimatePresence>
   );
 }

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -2,7 +2,7 @@ import AnimatedBackground from "./AnimatedBackground";
 
 export default function LandingPage({ onEnter, onShowTips, onShowRules }) {
   return (
-    <>
+    <div className="page landing-page">
       <AnimatedBackground />
       <div className="landing">
         <h1 className="site-title">Costa Rica Trip 2025</h1>
@@ -25,6 +25,6 @@ export default function LandingPage({ onEnter, onShowTips, onShowRules }) {
           <button className="btn btn--schedule" onClick={onEnter}>🗓️ Activity Schedule</button>
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/components/RulesPage.jsx
+++ b/src/components/RulesPage.jsx
@@ -2,7 +2,7 @@ import AnimatedBackground from "./AnimatedBackground";
 
 export default function RulesPage({ onBack }) {
   return (
-    <>
+    <div className="page rules-page">
       <AnimatedBackground />
       <div className="landing">
         <h1 className="site-title">🌴 Expectations &amp; House Rules 🐒</h1>
@@ -13,6 +13,6 @@ export default function RulesPage({ onBack }) {
         </ul>
         <button className="btn btn--rules" onClick={onBack}>Back</button>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/components/TipsPage.jsx
+++ b/src/components/TipsPage.jsx
@@ -3,7 +3,7 @@ import RouteMap from "./RouteMap";
 
 export default function TipsPage({ onBack }) {
   return (
-    <>
+    <div className="page tips-page">
       <AnimatedBackground />
 
       <div className="container">
@@ -136,6 +136,6 @@ export default function TipsPage({ onBack }) {
           <button className="btn btn--rules" onClick={onBack}>Back</button>
         </div>
       </div>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- animate navigation between landing, schedule, tips, and rules pages
- wrap each page in a container for smooth motion
- respect user prefers-reduced-motion settings

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d34343c248333a10ae4c4100ebd3b