### PR TITLE
style: enlarge badges and roster names

### DIFF
--- a/src/components/SignupPage.jsx
+++ b/src/components/SignupPage.jsx
@@ -384,7 +384,7 @@ export default function SignupPage({ onBack }) {
                             <span className="badge">{people.length}</span>
                           </div>
                           {people.length > 0 && (
-                            <div className="day__item-preferred" style={{ fontSize: 12 }}>
+                            <div className="day__item-preferred roster-names">
                               {people.join(", ")}
                             </div>
                           )}

--- a/src/index.css
+++ b/src/index.css
@@ -118,6 +118,7 @@ body{
   color:#063; border-radius:999px; padding:6px 8px;
 }
 .day__item-preferred{margin-top:6px; font-size:12px; color:var(--muted)}
+.roster-names{font-size:14px; font-weight:600}
 
 /* compact mode */
 body.compact .day__item{padding:8px 10px}
@@ -154,14 +155,14 @@ body.compact .days-grid{gap:12px}
 /* small count pill */
 .badge{
   display:inline-block;
-  min-width:20px;
-  padding:0 8px;
-  height:20px;
-  line-height:20px;
+  min-width:24px;
+  padding:0 10px;
+  height:24px;
+  line-height:24px;
   border-radius:999px;
-  background:#ff6b6b;
-  color:#fff;
-  font-size:12px;
+  background: linear-gradient(90deg, var(--sun), var(--sea));
+  color:#063;
+  font-size:14px;
   font-weight:800;
   vertical-align:middle;
   margin-left:6px;


### PR DESCRIPTION
## Summary
- Enlarge numeric badges with larger dimensions, font, and gradient styling
- Add roster-names utility class for bigger, bolder participant names
- Apply new roster-names class in SignupPage roster list

## Testing
- `npx eslint src/components/SignupPage.jsx` *(fails: 'items' is assigned a value but never used)*
- `npm run build`
- `npm run dev` *(fails: Missing script "dev" )*

------
https://chatgpt.com/codex/tasks/task_e_689dd2fdde088333a54b1faad5266ad8