### PR TITLE
Style roster names and count badges

### DIFF
--- a/src/components/SignupPage.jsx
+++ b/src/components/SignupPage.jsx
@@ -387,7 +387,9 @@ export default function SignupPage({ onBack }) {
                           </div>
                           {people.length > 0 && (
                             <div className="day__item-preferred roster-names">
-                              {people.join(", ")}
+                              {people.map(person => (
+                                <span key={person} className="roster-name">{person}</span>
+                              ))}
                             </div>
                           )}
                         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -118,7 +118,8 @@ body{
   color:#063; border-radius:999px; padding:6px 8px;
 }
 .day__item-preferred{margin-top:6px; font-size:12px; color:var(--muted)}
-.roster-names{font-size:24px; font-weight:600}
+.roster-names{font-size:24px; font-weight:600; color:var(--ink); display:flex; flex-wrap:wrap; gap:8px}
+.roster-name{background:var(--paper); border:1px solid var(--line); border-radius:8px; padding:2px 8px}
 
 /* compact mode */
 body.compact .day__item{padding:8px 10px}
@@ -166,6 +167,8 @@ body.compact .days-grid{gap:12px}
   font-weight:800;
   vertical-align:middle;
   margin-left:6px;
+  border:1px solid rgba(255,255,255,.6);
+  box-shadow:0 2px 4px rgba(15,23,42,.1);
 }
 
 .signup-count{


### PR DESCRIPTION
## Summary
- Display roster names as individual pill elements for better readability
- Add border and shadow styling to count badges to complement larger size

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689de738e3008333bcf151f533142dea