### PR TITLE
refactor: rename core optional labels

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -100,10 +100,10 @@ export default function App() {
           </div>
 
           <p className="site-explainer">
-            We scheduled a few <strong>Core activities</strong> by popular demand
-            and left the rest as <strong>Open time</strong> for you to book (or
-            chill) individually. We’ve shared both the Core picks and other
-            possibilities with the concierge.
+            We scheduled a few <strong>Majority Preference activities</strong> by
+            popular demand and left the rest as <strong>Open time</strong> for you
+            to book (or chill) individually. We’ve shared both the Majority
+            Preference picks and Other Preference options with the concierge.
           </p>
 
           {/* Organized actions: utilities on the left, nav on the right */}
@@ -137,9 +137,9 @@ export default function App() {
 
             <div className="actions__group">
               <div className="legend">
-                <span className="tag tag--core">Core</span>
+                <span className="tag tag--majority">Majority Preference</span>
                 <span className="tag tag--open">Open</span>
-                <span className="tag tag--optional">Optional</span>
+                <span className="tag tag--other">Other Preference</span>
                 <span className="tag tag--depart">Departure</span>
               </div>
               <button className="btn btn--home" onClick={() => navigate("landing")}>

--- a/src/components/OptionPanel.jsx
+++ b/src/components/OptionPanel.jsx
@@ -4,8 +4,10 @@ import React from "react";
 function classify(name = "") {
   const n = name.toLowerCase();
   if (n.includes("departure")) return { kind: "depart", label: "Departure" };
-  if (n.includes("core booking")) return { kind: "core", label: "Core" };
-  if (n.includes("optional")) return { kind: "optional", label: "Optional" };
+  if (n.includes("majority preference"))
+    return { kind: "majority", label: "Majority Preference" };
+  if (n.includes("other preference"))
+    return { kind: "other", label: "Other Preference" };
   if (/—\s*open\b/i.test(name) || n.endsWith(" — Open".toLowerCase())) {
     return { kind: "open", label: "Open" };
   }

--- a/src/components/SignupPage.jsx
+++ b/src/components/SignupPage.jsx
@@ -71,9 +71,9 @@ function PriceLine({ fullPriceLabel, depositLabel }) {
   );
 }
 
-// Determines if a schedule item is your “Open/Optional Sign-Ups (smaller-group items)” row
+// Determines if a schedule item is your “Other Preference Sign-Ups (smaller-group items)” row
 function isOpenOptionalRow(name) {
-  return /open\/optional sign-ups/i.test(name) || /open\/optional/i.test(name);
+  return /other preference sign-ups/i.test(name) || /other preference/i.test(name);
 }
 
 export default function SignupPage({ onBack }) {
@@ -282,24 +282,24 @@ export default function SignupPage({ onBack }) {
           <div className="site-header__titles">
             <h1 className="site-title">Activity Sign-Ups & Deposits</h1>
             <p className="site-subtitle">
-              We built a schedule that locks in the <strong>core activities most of us want</strong> while leaving plenty of open time to make the trip your own.
+              We built a schedule that locks in the <strong>Majority Preference activities most of us want</strong> while leaving plenty of open time to make the trip your own.
             </p>
           </div>
 
           <div className="site-explainer" style={{ marginTop: 8, lineHeight: 1.5 }}>
-            If you pick one of the <strong>Open/Optional small-group items we’re reserving now</strong> (below),
-            we’ll include it in our concierge reservation and collect a deposit here. For other non-core ideas,
+            If you pick one of the <strong>Other Preference small-group items we’re reserving now</strong> (below),
+            we’ll include it in our concierge reservation and collect a deposit here. For other ideas beyond the Majority Preference picks,
             we can share contact info to self-book—or tell us and we’ll see if we can add it.
           </div>
 
           <div style={{ marginTop: 10, display: "flex", gap: 8, flexWrap: "wrap" }}>
-            <Badge tone="ok">Reservation-backed optional items: Mangrove • Waterfall Rappelling • Surf Lessons • Jungle Tubing</Badge>
+            <Badge tone="ok">Reservation-backed Other Preference items: Mangrove • Waterfall Rappelling • Surf Lessons • Jungle Tubing</Badge>
           </div>
         </header>
 
         {/* 3-column layout */}
         <div className="info-grid">
-          {/* Column 1: Schedule + selections, with optional checklist where applicable */}
+          {/* Column 1: Schedule + selections, with other-preference checklist where applicable */}
           <section className="info-card info-card--span4">
             <div className="kicker">Step 1</div>
             <h2 className="info-title">Choose Activities</h2>

--- a/src/data/deposits.js
+++ b/src/data/deposits.js
@@ -3,7 +3,7 @@
 // Normalize helper
 const norm = s => String(s || "").trim().toLowerCase();
 
-// These four are the “Open/Optional Sign-Ups we’ll reserve now”
+// These four are the “Other Preference Sign-Ups we’ll reserve now”
 export const OPTIONAL_SIGNUPS_KEYS = [
   "damas island mangrove",
   "waterfall rappelling",
@@ -51,7 +51,7 @@ export const activityCatalog = [
     deposit: 20,
   },
 
-  // Core/common items so detectDeposit() still works nicely
+  // Majority/common items so detectDeposit() still works nicely
   {
     key: "public catamaran",
     aliases: ["public catamaran tour", "catamaran (public)"],

--- a/src/data/schedule.js
+++ b/src/data/schedule.js
@@ -2,34 +2,34 @@
 export const schedule = [
   { date: "Sat Aug 30", items: [
       { name: "Day: Arrival & settle in (check-in, beach walk, sunset) — Open" },
-      { name: "Evening: Chef Dinner at the villa — Core Booking (~7:00 PM)" },
+      { name: "Evening: Chef Dinner at the villa — Majority Preference (~7:00 PM)" },
   ]},
   { date: "Sun Aug 31", items: [
-      { name: "Morning → Afternoon: Manuel Antonio National Park (Group Day) — Core Booking. Early entry recommended; beach/café time after the park is open." },
+      { name: "Morning → Afternoon: Manuel Antonio National Park (Group Day) — Majority Preference. Early entry recommended; beach/café time after the park is open." },
       { name: "Evening: Casual dinner in town — Open" },
   ]},
   { date: "Mon Sep 01", items: [
-      { name: "Morning: Coffee Tour — Core Booking (pickup ~7:30 AM)" },
+      { name: "Morning: Coffee Tour — Majority Preference (pickup ~7:30 AM)" },
       { name: "Midday/Afternoon: Beach time / pool time — Open" },
       { name: "Evening: Free or informal groups — Open" },
   ]},
   { date: "Tue Sep 02", items: [
-      { name: "Early: Bird Watching — Core Booking (pre-dawn start)" },
-      { name: "Midday: Public Catamaran Tour — Core Booking (check-in ~12:30 PM)" },
+      { name: "Early: Bird Watching — Majority Preference (pre-dawn start)" },
+      { name: "Midday: Public Catamaran Tour — Majority Preference (check-in ~12:30 PM)" },
       { name: "Evening: Free — Open" },
   ]},
   { date: "Wed Sep 03", items: [
-      { name: "Day: Open/Optional Sign-Ups (smaller-group items). Examples: Damas Island Mangrove Tour, Waterfall Rappelling, Surf Lessons, Jungle Tubing. We’ll help coordinate day-before if a small group wants one of these." },
-      { name: "Evening: Private Chef Dinner at the villa — Core Booking (~7:00 PM)" },
+      { name: "Day: Other Preference Sign-Ups (smaller-group items). Examples: Damas Island Mangrove Tour, Waterfall Rappelling, Surf Lessons, Jungle Tubing. We’ll help coordinate day-before if a small group wants one of these." },
+      { name: "Evening: Private Chef Dinner at the villa — Majority Preference (~7:00 PM)" },
   ]},
   { date: "Thu Sep 04", items: [
       { name: "Morning: Flex / Weather Buffer — Open (Use this slot to slide anything weather-impacted from earlier in the week.)" },
       { name: "Midday/Afternoon: Town/beach/café time — Open" },
-      { name: "Evening: Optional Night Jungle Tour if a sub-group wants it — Open" },
+      { name: "Evening: Night Jungle Tour if a sub-group wants it — Open" },
   ]},
   { date: "Fri Sep 05", items: [
       { name: "Day: Beach Day (wrap-up vibes) — Open" },
-      { name: "Evening: Night Jungle Tour — Core Booking (~7:30 PM)" },
+      { name: "Evening: Night Jungle Tour — Majority Preference (~7:30 PM)" },
   ]},
   { date: "Sat Sep 06", items: [
       { name: "Any: Pack, brunch, airport transfers for 2:00 PM flight — Departure" },

--- a/src/index.css
+++ b/src/index.css
@@ -412,12 +412,12 @@ body.compact .days-grid{gap:12px}
   background:#fbfeff;
   border:1px solid #eaf3fb;
 }
-.tag--core{
+.tag--majority{
   background: linear-gradient(135deg, var(--sea), var(--sun));
   color:#063; border-color: transparent;
 }
 .tag--open{ background:#eef8ff; color:#044; }
-.tag--optional{
+.tag--other{
   background: linear-gradient(135deg, var(--orchid), var(--sea));
   color:#fff; border-color: transparent;
 }
@@ -430,14 +430,14 @@ body.compact .days-grid{gap:12px}
   position:absolute; left:-1px; top:-1px; bottom:-1px; width:6px;
   border-top-left-radius:12px; border-bottom-left-radius:12px;
 }
-.item--core{ background:#f7fffb; }
-.item--core::before{ background: linear-gradient(180deg, var(--sea), var(--sun)); }
+.item--majority{ background:#f7fffb; }
+.item--majority::before{ background: linear-gradient(180deg, var(--sea), var(--sun)); }
 
 .item--open{ background:#ffffff; }
 .item--open::before{ background: #dfeffb; }
 
-.item--optional{ background:#f7f3ff; }
-.item--optional::before{ background: linear-gradient(180deg, var(--orchid), var(--sea)); }
+.item--other{ background:#f7f3ff; }
+.item--other::before{ background: linear-gradient(180deg, var(--orchid), var(--sea)); }
 
 .item--depart{ background:#fafafa; }
 


### PR DESCRIPTION
## Summary
- Reclassify activities as "Majority Preference" or "Other Preference" and rename associated tags/classes
- Update schedule data and signup copy to reflect new terminology
- Revise legend and site explainer to use new terms

## Testing
- ⚠️ `npm test` (missing script: test)
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e8727478c833386990726fddb7700