### PR TITLE
Use PapaParse for roster CSV parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "framer-motion": "^12.23.12",
         "leaflet": "^1.9.4",
+        "papaparse": "^5.5.3",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -2748,6 +2749,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "framer-motion": "^12.23.12",
     "leaflet": "^1.9.4",
+    "papaparse": "^5.5.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/src/components/SignupPage.jsx
+++ b/src/components/SignupPage.jsx
@@ -9,6 +9,7 @@ import {
   getFullPriceInfo,
   detectDeposit
 } from "../data/deposits";
+import Papa from "papaparse";
 
 // 👉 Set these:
 const VENMO_USER = "John-Kenny-16";
@@ -26,18 +27,13 @@ function venmoUrl(amount, note) {
   });
   return `https://venmo.com/?${params.toString()}`;
 }
-
-// Tiny CSV parser
+// CSV parser using PapaParse
 function parseCSV(text) {
-  const rows = text.trim().split(/\r?\n/).map(r => r.split(","));
-  if (rows.length === 0) return [];
-  const [head, ...rest] = rows;
-  const normHead = head.map(h => String(h || "").trim().toLowerCase());
-  return rest.map(r => {
-    const obj = {};
-    r.forEach((v, i) => (obj[normHead[i] || `col${i}`] = v));
-    return obj;
-  });
+  return Papa.parse(text, {
+    header: true,
+    skipEmptyLines: true,
+    transformHeader: h => String(h || "").trim().toLowerCase(),
+  }).data;
 }
 
 // Simple badge


### PR DESCRIPTION
## Summary
- replace custom CSV parser with PapaParse
- parse roster headers to lowercase during fetches
- add papaparse dependency

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e99809cd4833393449aead13bdff6